### PR TITLE
Fix .gitignore to not exclude already committed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,6 @@
 *.gch
 *.pch
 
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
 # Fortran module files
 *.mod
 *.smod
@@ -28,7 +23,6 @@
 *.lai
 *.la
 *.a
-*.lib
 
 # Executables
 *.exe


### PR DESCRIPTION
The changes introduced in #10 make the following (already committed) files ignored:
```
/Source/ThirdParty/DiscordRpcLibrary/Win64/discord-rpc.dll
/Source/ThirdParty/DiscordRpcLibrary/Win64/discord-rpc.lib
/Source/ThirdParty/DiscordRpcLibrary/Win64/discord_game_sdk.dll
/Source/ThirdParty/DiscordRpcLibrary/Win64/discord_game_sdk.dll.lib
/Source/ThirdParty/DiscordRpcLibrary/Win64/discord_game_sdk.dylib
/Source/ThirdParty/DiscordRpcLibrary/Win64/discord_game_sdk.so
```

This doesn't affect them at the moment, but trying to add new files with these extensions or attempting to delete and then re-add the mentioned files won't work. The PR fixes the inconsistency.